### PR TITLE
fix: ensure code runs on Node.js v6

### DIFF
--- a/lib/span.js
+++ b/lib/span.js
@@ -63,18 +63,18 @@ class Span extends opentracing.Span {
       delete tags['user.email']
     }
 
-    const entries = Object.entries(tags)
+    const keys = Object.keys(tags)
 
-    if (entries.length === 0) return
+    if (keys.length === 0) return
 
     // While the Node.js agent will sanitize the keys for us, it will also log
     // a warning each time. As periods are the norm in OpenTracing, we don't
     // want to log a warning each time a period is found, so we'll sanitize the
     // keys before forwarding the tags to the agent
     const sanitizedTags = {}
-    for (const [key, value] of entries) {
+    for (const key of keys) {
       const sanitizedKey = key.replace(illigalChars, '_')
-      sanitizedTags[sanitizedKey] = value
+      sanitizedTags[sanitizedKey] = tags[key]
     }
 
     this._span.addTags(sanitizedTags)

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,39 +1,21 @@
 'use strict'
 
-const Filters = require('elastic-apm-node/lib/filters')
-const symbols = require('elastic-apm-node/lib/symbols')
-const agent = require('elastic-apm-node')
+const agent = require('elastic-apm-node').start({ captureExceptions: false })
 
 exports.setup = setup
 exports.getAgent = getAgent
 
-let uncaughtExceptionListeners = process._events.uncaughtException
-
 function getAgent (conf = {}) {
-  if (!conf.captureExceptions) conf.captureExceptions = false
-  return agent.start(conf)
+  return agent
 }
 
 function setup (runTest) {
   return function (t) {
-    uncaughtExceptionListeners = process._events.uncaughtException
-    process.removeAllListeners('uncaughtException')
-
     t.on('end', clean)
-
     runTest(t)
   }
 }
 
 function clean () {
-  global[symbols.agentInitialized] = null
-  process._events.uncaughtException = uncaughtExceptionListeners
-  if (agent) {
-    agent._errorFilters = new Filters()
-    agent._transactionFilters = new Filters()
-    agent._spanFilters = new Filters()
-    if (agent._instrumentation && agent._instrumentation._hook) {
-      agent._instrumentation._hook.unhook()
-    }
-  }
+  agent._instrumentation.currentTransaction = null
 }


### PR DESCRIPTION
`Object.entries` isn't available on Node.js 6 and there were issues re-starting the agent when not using AsyncHooks. But since the only thing we care about in these tests are resetting the active transaction, I changed it to just set `currentTransaction` to `null` before each test run