### PR TITLE
fix: use the labels API instead of the deprecated tags API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An [OpenTracing](https://opentracing.io/) bridge for the [Elastic APM Node.js Ag
 
 This module have [`elastic-apm-node`](https://www.npmjs.com/package/elastic-apm-node) as a peer dependency.
 
+Version 2.10.0 or higher of the Elastic APM Agent is required in order to use this module.
+
 ## Installation
 
 ```

--- a/lib/span.js
+++ b/lib/span.js
@@ -79,7 +79,7 @@ class Span extends opentracing.Span {
       sanitizedTags[sanitizedKey] = tags[key]
     }
 
-    this._span.addTags(sanitizedTags)
+    this._span.addLabels(sanitizedTags)
   }
 
   _log (logs, timestamp) {

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "elastic-apm-node": "^2.4.0",
+    "elastic-apm-node": "^2.16.2",
     "mocha": "^5.2.0",
     "standard": "^12.0.1",
     "tape": "^4.9.2"
   },
   "peerDependencies": {
-    "elastic-apm-node": "^2.4.0"
+    "elastic-apm-node": "^2.10.0"
   },
   "keywords": [
     "elastic",

--- a/test/span.js
+++ b/test/span.js
@@ -35,7 +35,7 @@ test('tags', setup(function (t) {
 
   span.addTags(tags)
 
-  t.deepEqual(span._span._tags, {
+  t.deepEqual(span._span._labels, {
     a: '1',
     a_b: '4'
   }, 'should set expected tags')
@@ -55,7 +55,7 @@ test('tag: type', setup(function (t) {
   const span = tracer.startSpan()
   span.setTag('type', 'foo')
   t.equal(span._span.type, 'foo')
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
   t.end()
 }))
 
@@ -64,7 +64,7 @@ test('tag: result', setup(function (t) {
   const span = tracer.startSpan()
   span.setTag('result', 'foo')
   t.equal(span._span.result, 'foo')
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
   t.end()
 }))
 
@@ -73,7 +73,7 @@ test('tag: http.status_code', setup(function (t) {
   const span = tracer.startSpan()
   span.setTag('http.status_code', 200)
   t.equal(span._span.result, 'HTTP 2xx')
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
   t.end()
 }))
 
@@ -90,7 +90,7 @@ test('tag: user.*', setup(function (t) {
     username: 'bar',
     email: 'baz'
   })
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
   t.end()
 }))
 
@@ -104,7 +104,7 @@ test('log - error, but no details', setup(function (t) {
 
   const span = tracer.startSpan()
   span.log({ event: 'error' })
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()
@@ -125,7 +125,7 @@ test('log - error, with error object', setup(function (t) {
 
   const span = tracer.startSpan()
   span.log({ event: 'error', 'error.object': error })
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()
@@ -143,7 +143,7 @@ test('log - error, with string message', setup(function (t) {
 
   const span = tracer.startSpan()
   span.log({ event: 'error', message: error })
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()
@@ -166,7 +166,7 @@ test('log - error, with error object + timestamp', setup(function (t) {
 
   const span = tracer.startSpan()
   span.log({ event: 'error', 'error.object': error }, timestamp)
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()
@@ -186,7 +186,7 @@ test('log - error, with string message + timestamp', setup(function (t) {
 
   const span = tracer.startSpan()
   span.log({ event: 'error', message: error }, timestamp)
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()
@@ -210,7 +210,7 @@ test('log - error, with error object + message + timestamp', setup(function (t) 
 
   const span = tracer.startSpan()
   span.log({ event: 'error', 'error.object': error, message }, timestamp)
-  t.equal(span._span._tags, null)
+  t.equal(span._span._labels, null)
 
   tracer._agent.captureError = captureError
   t.end()

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -83,7 +83,7 @@ test('#startSpan(name, {tags: {...}})', setup(function (t) {
   t.equal(span._span.name, 'foo', 'should use given name')
   t.equal(span._span.type, 'bar', 'should use given type')
 
-  t.deepEqual(span._span._tags, {
+  t.deepEqual(span._span._labels, {
     a: '1',
     a_b: '4'
   }, 'should set expected tags')

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const agent = require('elastic-apm-node').start({ captureExceptions: false })
+const agent = require('elastic-apm-node').start({
+  captureExceptions: false,
+  centralConfig: false,
+  metricsInterval: 0
+})
 
 exports.setup = setup
 exports.getAgent = getAgent


### PR DESCRIPTION
In version 2.10.0 of the Node.js agent, the tags API was deprecated in favor of the labels API.

BREAKING CHANGE: The minimum version of the Elastic APM Agent compatible with this module is now 2.10.0